### PR TITLE
Fix skip logic for missing files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "nber-cli"
-version = "0.1.1"
+version = "0.1.2"
 description = "A command-line tool to download NBER papers."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/nber_cli/downloader.py
+++ b/src/nber_cli/downloader.py
@@ -125,15 +125,19 @@ async def update_paper_state(paper_id: str, status: str):
 
 async def download_paper(paper_id: str, save_path: str):
     """下载单个NBER论文"""
-    if await get_paper_state(paper_id) == 'ok':
-        logger.info(f"Skipping {paper_id}, already downloaded.")
-        return
-
-    url = f"https://www.nber.org/papers/{paper_id}.pdf"
     filepath = os.path.join(save_path, f"{paper_id}.pdf")
 
     # 确保保存路径存在
     os.makedirs(save_path, exist_ok=True)
+
+    state = await get_paper_state(paper_id)
+    if state == 'ok' and os.path.exists(filepath):
+        logger.info(f"Skipping {paper_id}, already downloaded.")
+        return
+    if state == 'ok' and not os.path.exists(filepath):
+        logger.info(f"{paper_id} marked as downloaded but file missing, re-downloading.")
+
+    url = f"https://www.nber.org/papers/{paper_id}.pdf"
 
     ua = UserAgent()
     headers = {'User-Agent': ua.random}


### PR DESCRIPTION
## Summary
- check for file presence when skipping downloads
- log when DB says downloaded but file missing

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685bd4bee05c8320998f2174b0bfc276